### PR TITLE
Improve the finding of Animation Window

### DIFF
--- a/Packages/com.redcandlegames.animation-clip-search/Editor/AnimationWindowExtensions.cs
+++ b/Packages/com.redcandlegames.animation-clip-search/Editor/AnimationWindowExtensions.cs
@@ -35,18 +35,12 @@ namespace RedCandleGames.Editor
             }
         }
         
-        private static EditorWindow GetAnimationWindow()
+        internal static EditorWindow GetAnimationWindow()
         {
-            System.Type animationWindowType = System.Type.GetType("UnityEditor.AnimationWindow, UnityEditor");
-            if (animationWindowType != null)
-            {
-                UnityEngine.Object[] windows = Resources.FindObjectsOfTypeAll(animationWindowType);
-                if (windows.Length > 0)
-                {
-                    return windows[0] as EditorWindow;
-                }
-            }
-            return null;
+            if (!EditorWindow.HasOpenInstances<AnimationWindow>())
+                return null;
+
+            return EditorWindow.GetWindow<AnimationWindow>(null, false);
         }
         
         private static void OnClipSelectedFromSearch(AnimationClip clip)

--- a/Packages/com.redcandlegames.animation-clip-search/Editor/AnimationWindowMinimalMode.cs
+++ b/Packages/com.redcandlegames.animation-clip-search/Editor/AnimationWindowMinimalMode.cs
@@ -12,6 +12,8 @@ namespace RedCandleGames.Editor
     [InitializeOnLoad]
     public static class AnimationWindowMinimalMode
     {
+        private const float _checkingInterval = 1 / 10f;
+        private static double _lastCheckingTime;
         private static Button searchButton;
         private static EditorWindow lastAnimationWindow;
         
@@ -22,6 +24,12 @@ namespace RedCandleGames.Editor
         
         private static void OnEditorUpdate()
         {
+            var curTime = EditorApplication.timeSinceStartup;
+            if (curTime - _lastCheckingTime < _checkingInterval)
+                return;
+
+            _lastCheckingTime = curTime;
+
             var animationWindow = AnimationWindowExtensions.GetAnimationWindow();
             
             if (animationWindow != null)

--- a/Packages/com.redcandlegames.animation-clip-search/Editor/AnimationWindowMinimalMode.cs
+++ b/Packages/com.redcandlegames.animation-clip-search/Editor/AnimationWindowMinimalMode.cs
@@ -22,7 +22,7 @@ namespace RedCandleGames.Editor
         
         private static void OnEditorUpdate()
         {
-            var animationWindow = GetAnimationWindow();
+            var animationWindow = AnimationWindowExtensions.GetAnimationWindow();
             
             if (animationWindow != null)
             {
@@ -37,24 +37,7 @@ namespace RedCandleGames.Editor
                 CleanupMinimalUI();
             }
         }
-        
-        private static EditorWindow GetAnimationWindow()
-        {
-            var assembly = typeof(EditorWindow).Assembly;
-            var animationWindowType = assembly.GetType("UnityEditor.AnimationWindow");
-            
-            if (animationWindowType != null)
-            {
-                var windows = Resources.FindObjectsOfTypeAll(animationWindowType);
-                if (windows.Length > 0)
-                {
-                    return windows[0] as EditorWindow;
-                }
-            }
-            
-            return null;
-        }
-        
+
         private static void InjectMinimalUI(EditorWindow animWindow)
         {
             try


### PR DESCRIPTION
- Use built-in API `EditorWindow.HasOpenInstances` then `EditorWindow.GetWindow` to get the `AnimationWindow` instance. (But they all use `Resources.FindObjectsOfTypeAll` still)
- Avoid getting the window instance in every editor update